### PR TITLE
Support submodules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -306,23 +306,10 @@ fn matches_desired_prefix(hash: &[u8; SHA1_BYTE_LENGTH], prefix: &HashPrefix) ->
 }
 
 fn create_git_object_file(search_result: &HashMatch) -> io::Result<()> {
-    let compressed_object = zlib_compress(&search_result.data)?;
-
-    let md = std::fs::metadata(".git").unwrap();
-    let contents;
-    let mut dir = ".git";
-
-    if md.is_file() {
-        contents = fs::read_to_string(".git")?;
-
-        if contents.starts_with(&"gitdir: ") {
-            dir = &contents[8..];
-        } else {
-            fail_with_message(".git must be a directory or submodule");
-        }
-    }
-
-    let dir_path = format!("{}/objects/{:02x}", dir, search_result.hash[0]);
+    let compressed_object = zlib_compress(&search_result.data)?;b
+    let git_dir_bytes = run_command("git", &["rev-parse", "--git-dir"]);
+    let git_dir = &String::from_utf8(git_dir_bytes).expect("git rev-parse --git-dir returned invalid utf8");
+    let dir_path = format!("{}/objects/{:02x}", git_dir, search_result.hash[0]);
     let file_path = format!(
         "{}/{}",
         dir_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,8 +308,9 @@ fn matches_desired_prefix(hash: &[u8; SHA1_BYTE_LENGTH], prefix: &HashPrefix) ->
 fn create_git_object_file(search_result: &HashMatch) -> io::Result<()> {
     let compressed_object = zlib_compress(&search_result.data)?;
     let git_dir_bytes = run_command("git", &["rev-parse", "--git-dir"]);
-    let mut git_dir = &String::from_utf8(git_dir_bytes).expect("git rev-parse --git-dir returned invalid utf8");
-    git_dir.truncate(git_dir.len() - 1);
+    let mut git_dir = String::from_utf8(git_dir_bytes).expect("git rev-parse --git-dir returned invalid utf8");
+    let len = git_dir.len();
+    git_dir.truncate(len - 1);
     let dir_path = format!("{}/objects/{:02x}", git_dir, search_result.hash[0]);
     let file_path = format!(
         "{}/{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ fn matches_desired_prefix(hash: &[u8; SHA1_BYTE_LENGTH], prefix: &HashPrefix) ->
 }
 
 fn create_git_object_file(search_result: &HashMatch) -> io::Result<()> {
-    let compressed_object = zlib_compress(&search_result.data)?;b
+    let compressed_object = zlib_compress(&search_result.data)?;
     let git_dir_bytes = run_command("git", &["rev-parse", "--git-dir"]);
     let git_dir = &String::from_utf8(git_dir_bytes).expect("git rev-parse --git-dir returned invalid utf8");
     let dir_path = format!("{}/objects/{:02x}", git_dir, search_result.hash[0]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,8 @@ fn matches_desired_prefix(hash: &[u8; SHA1_BYTE_LENGTH], prefix: &HashPrefix) ->
 fn create_git_object_file(search_result: &HashMatch) -> io::Result<()> {
     let compressed_object = zlib_compress(&search_result.data)?;
     let git_dir_bytes = run_command("git", &["rev-parse", "--git-dir"]);
-    let git_dir = &String::from_utf8(git_dir_bytes).expect("git rev-parse --git-dir returned invalid utf8");
+    let mut git_dir = &String::from_utf8(git_dir_bytes).expect("git rev-parse --git-dir returned invalid utf8");
+    git_dir.truncate(git_dir.len() - 1);
     let dir_path = format!("{}/objects/{:02x}", git_dir, search_result.hash[0]);
     let file_path = format!(
         "{}/{}",


### PR DESCRIPTION
This solves the case where `.git` is a file and links to a directory in the main repository.

Solves #4