### PR TITLE
Fix runtime crash on Windows due to type mismatch(Fixes #20 )

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ impl<H: GitHash> HashSearchWorker<H> {
                     .copy_host_slice(partially_hashed_commit.intermediate_state.as_ref())
                     .build()?,
             )
-            .arg_named(BASE_PADDING_SPECIFIER_ARG, 0) // filled in later
+            .arg_named(BASE_PADDING_SPECIFIER_ARG, 0u64) // filled in later
             .arg(
                 &Buffer::builder()
                     .queue(queue.clone())


### PR DESCRIPTION
It seems that Rust chooses the wrong type for `BASE_PADDING_SPECIFIER_ARG` argument for some reason and it causes lucky_commit to crash. Full issue description: #20 

This PR fixes this by explicitly specifying the argument type.