### PR TITLE
Add support for a help flag

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -9,6 +9,17 @@ use std::{
     process::{self, Command, Stdio},
 };
 
+fn usage() -> ! {
+    eprintln!(
+        "\
+        Usage: lucky_commit [commit-hash-prefix]\n\
+        \n\
+        `commit-hash-prefix` must contain hex characters and underscores. An underscore indicates \
+        that the hash may have any value in the given position.
+            "
+    );
+    process::exit(1)
+}
 fn main() -> Result<(), ParseHashSpecErr> {
     let args = env::args().collect::<Vec<String>>();
     let maybe_prefix = match args.as_slice() {
@@ -16,17 +27,10 @@ fn main() -> Result<(), ParseHashSpecErr> {
             benchmark::run_benchmark();
             process::exit(0)
         }
+        [_, arg] if arg == "-h" || arg == "--help" => usage(),
         [_, prefix] => Some(prefix.as_str()),
         [_] => None,
-        _ => {
-            eprintln!("\
-                Usage: lucky_commit [commit-hash-prefix]\n\
-                \n\
-                `commit-hash-prefix` must contain hex characters and underscores. An underscore indicates \
-                that the hash may have any value in the given position.
-            ");
-            process::exit(1)
-        }
+        _ => usage(),
     };
 
     let existing_commit = spawn_git(&["cat-file", "commit", "HEAD"], None);


### PR DESCRIPTION
When I reach for a binary I don't use often, I usually start with a `man $bin` or `$bin -h` (/ `--help`) to get my bearings and ensure I don't completely misuse the thing. This currently doesn't work with lucky-commit, resulting in a laconic

> Error: hash spec contains invalid character '-' (only hex characters and underscores are allowed)

(which admittedly is better than failing silently or doing something silly).

To get the help text it's necessary to be lucky enough to mistakenly give it 2 args, thus failing to match any case. I think it's not great, and having support for a help flag would be nice.