### PR TITLE
Print new hash on stdout on success

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -73,6 +73,8 @@ fn run_lucky_commit<H: GitHashFn>(
             None,
         );
 
+        println!("new hash: {}", new_hash);
+
         Ok(())
     } else {
         eprintln!(


### PR DESCRIPTION
While it's currently possible to check the new value of HEAD, it becomes an issue with #29. While looking up the new commit by prefix might be possible it's annoying. And it becomes very difficult when rewriting on a oid as then the entire repository has to be looked up (since the new commit is "detached")